### PR TITLE
Fixed issue in onApplicationStart

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -54,7 +54,6 @@
 				userAccountName		=	'#application.twitterUser#',
 				parseResults = true
 				);
-				return true;
 			</cfscript>		
 		</cfif>
 		<cfset application.utils = createObject("component", "components.utils")>

--- a/install/install.txt
+++ b/install/install.txt
@@ -10,5 +10,6 @@ You must create a myaggregator datasource. The SQL for building it is provided i
 run on MySQL 4 or 5, and will require modification to run with SQL Server, Access and perhaps other databases.
 
 Edit Application.cfc onApplicationStart variables to match your needs.
+Create a directory named "temp" underneath the scheduled/ directory
 Edit createschedules.cfm to use the right URL for your site, then run it once to setup the scheduled tasks.
 


### PR DESCRIPTION
Removed a return statement from onApplicationStart that was causing this function to exist prematurely when the twitter functionality was turned on, resulting in various application scope variables not being set.

Also made a minor addition to install/install.txt
